### PR TITLE
PM4 final update - AdvancedScoreboard v1.5

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,9 +1,17 @@
 name: AdvancedScoreboard
 main: varion\AdvancedScoreboard
 author: Varion
-version: 1.3
-api: 3.0.0
+version: 1.5
+api: 4.0.0
 
 commands:
- as:
-  description: "Open AdvancedScoreboards menu"
+  as:
+    usage: "/as"
+    description: AdvancedScoreboard settings
+    permission: advancedscoreboard.use
+    permission-message: "You don't have permission to use this command."
+
+permissions:
+  advancedscoreboard.use:
+    description: "Open AdvancedScoreboards menu"
+    default: true  

--- a/src/varion/AdvancedScoreboard.php
+++ b/src/varion/AdvancedScoreboard.php
@@ -3,9 +3,9 @@
 namespace varion;
 
 use pocketmine\player\Player;
+use pocketmine\event\player\PlayerJoinEvent;
 use pocketmine\plugin\PluginBase;
 use pocketmine\utils\TextFormat as TF;
-use pocketmine\utils\TextFormat;
 use varion\Event\LevelChangeEvent;
 use pocketmine\command\{Command,CommandSender};
 use pocketmine\network\mcpe\protocol\RemoveObjectivePacket;
@@ -14,6 +14,7 @@ use pocketmine\network\mcpe\protocol\SetScorePacket;
 use pocketmine\network\mcpe\protocol\types\ScorePacketEntry;
 use pocketmine\network\NetworkSessionManager;
 use jojoe77777\FormAPI;
+use jojoe77777\FormAPI\SimpleForm;
 
 
 class AdvancedScoreboard extends PluginBase{
@@ -43,7 +44,7 @@ class AdvancedScoreboard extends PluginBase{
 	public static function getInstance() : AdvancedScoreboard{
 		return static::$plugin;
 	}
-
+ 
 	/**
 	* @param Player $player
 	* @param string $displayName
@@ -55,14 +56,13 @@ class AdvancedScoreboard extends PluginBase{
 		if(isset(self::$scoreboard[$player->getName()])){
 			$this->removeScore($player);
 		}
-		$session = new NetworkSession();
 		$packet = new SetDisplayObjectivePacket();
 		$packet->displaySlot = $displaySlot;
 		$packet->objectiveName = "objective";
 		$packet->displayName = $displayName;
 		$packet->criteriaName = "dummy";
 		$packet->sortOrder = $sortOrder;
-		$session->sendDataPacket($packet);
+  $player->getNetworkSession()->sendDataPacket($packet);
 		self::$scoreboard[$player->getName()] = $player->getName();
 	}
 
@@ -71,10 +71,9 @@ class AdvancedScoreboard extends PluginBase{
 	* @return void
 	*/
 	public function removeScore(Player $player) : void{
-		$session = new NetworkSession();
 		$packet = new RemoveObjectivePacket();
 		$packet->objectiveName = "objective";
-		$session->sendDataPacket($packet);
+		$player->getNetworkSession()->sendDataPacket($packet);
 		unset(self::$scoreboard[$player->getName()]);
 	}
 
@@ -83,8 +82,8 @@ class AdvancedScoreboard extends PluginBase{
         switch ($cmd->getName()) {
             case "as":
                 if ($sender instanceof Player) {
-                    $api = $this->getServer()->getPluginManager()->getPlugin("FormAPI");
-                    $form = $api->createSimpleForm(function (Player $sender, ?int $data){
+                 if($sender->hasPermission("advancedscoreboard.use")){
+                    $form = new SimpleForm(function (Player $sender, ?int $data){
                         if ($data === null){
                             return true;
                         }
@@ -103,15 +102,15 @@ class AdvancedScoreboard extends PluginBase{
                         }
                         return false;
                     });
-                    $form->setTitle(TextFormat::GOLD . "§lADVANCEDSCOREBOARD");
+                    $form->setTitle(TF::GOLD . "§lADVANCEDSCOREBOARD");
                     $form->setContent("Select an option");
-                    $form->addButton(TextFormat::BOLD . "§l§aShow Scoreboard");
-                    $form->addButton(TextFormat::BOLD . "§l§cHide Scoreboard");
-
+                    $form->addButton(TF::BOLD . "§l§aShow Scoreboard");
+                    $form->addButton(TF::BOLD . "§l§cHide Scoreboard");
                     $form->sendToPlayer($sender);
-                }
+               }
+              }
                 else{
-                    $sender->sendMessage(TextFormat::RED . "Use this Command in-game.");
+                    $sender->sendMessage(TF ::RED . "Use this Command in-game.");
                     return true;
                 }
                     }
@@ -150,18 +149,16 @@ class AdvancedScoreboard extends PluginBase{
 		if ($translate) {
 			$message = $this->translate($player, $message);
 		}
-
-		$pkline = new ScorePacketEntry();
+	 $pkline = new ScorePacketEntry();
 		$pkline->objectiveName = "objective";
 		$pkline->type = ScorePacketEntry::TYPE_FAKE_PLAYER;
 		$pkline->customName = $message;
 		$pkline->score = $line;
 		$pkline->scoreboardId = $line;
-		$session = new NetworkSession();
 		$packet = new SetScorePacket();
 		$packet->type = SetScorePacket::TYPE_CHANGE;
 		$packet->entries[] = $pkline;
-		$session->sendDataPacket($packet);
+		$player->getNetworkSession()->sendDataPacket($packet); 
 	}
 
 
@@ -180,14 +177,15 @@ class AdvancedScoreboard extends PluginBase{
      * @return string
      */
     public function translate(Player $player, string $message) : string{
-        $message = str_replace('{PING}', $player->getPing(), $message);
+        $message = str_replace('{PING}', $player->getNetworkSession()->getPing(), $message);
         $message = str_replace('{NAME}', $player->getName(), $message);
-        $message = str_replace('{IP}', $player->getAddress(), $message);
+        $message = str_replace('{X}', $player->getPosition()->getX(), $message);
+        $message = str_replace('{Y}', $player->getPosition()->getY(), $message);
+        $message = str_replace('{Z}', $player->getPosition()->getZ(), $message);
+
+        $message = str_replace('{IP}', $player->getNetworkSession()->getIP(), $message);
         $message = str_replace('{ITEM_ID}', $player->getInventory()->getItemInHand()->getId(), $message);
-        $message = str_replace('{X}', $player->getFloorX(), $message);
-        $message = str_replace('{Y}', $player->getFloorY(), $message);
-        $message = str_replace('{Z}', $player->getFloorZ(), $message);
-        $level = $player->getLevel();
+        $level = $player->getWorld();
         $message = str_replace('{WORLDNAME}', $level->getFolderName(), $message);
         $message = str_replace('{WORLDPLAYERS}', count($level->getPlayers()), $message);
         $message = str_replace('{TICKS}', $this->getServer()->getTickUsage(), $message);
@@ -218,12 +216,10 @@ class AdvancedScoreboard extends PluginBase{
 			$message = str_replace('{MONEY}', $EconomyAPI->myMoney($player), $message);
 		}
 		$FactionsPro = $this->getServer()->getPluginManager()->getPlugin("FactionsPro");
-        $factionName = $FactionsPro->getPlayerFaction($player->getName());
 		if(!is_null($FactionsPro)){
 			$message = str_replace('{FACTION}', $FactionsPro->getPlayerFaction($player->getName()), $message);
             $message = str_replace('{FPOWER}', $FactionsPro->getFactionPower($factionName), $message);
 		}else{
-			$this->getLogger()->info(TF::DARK_PURPLE."FactionsPro not found");
 			$message = str_replace('{FACTION}', "PLUGIN NOT INSTALLED", $message);
 			$message = str_replace('{FPOWER}', "PLUGIN NOT INSTALLED", $message);
 		}
@@ -232,7 +228,6 @@ class AdvancedScoreboard extends PluginBase{
         if (!is_null($Logger)) {
             $message = str_replace('{COMBATLOGGER}', $Logger->getTagDuration($player), $message);
         }else{
-			$this->getLogger()->info(TF::DARK_PURPLE."CombatLogger not found");
 			$message = str_replace('{COMBATLOGGER}', "PLUGIN NOT INSTALLED", $message);
 	}
 

--- a/src/varion/AdvancedScoreboard.php
+++ b/src/varion/AdvancedScoreboard.php
@@ -2,7 +2,7 @@
 
 namespace varion;
 
-use pocketmine\Player;
+use pocketmine\player\Player;
 use pocketmine\plugin\PluginBase;
 use pocketmine\utils\TextFormat as TF;
 use pocketmine\utils\TextFormat;
@@ -12,6 +12,7 @@ use pocketmine\network\mcpe\protocol\RemoveObjectivePacket;
 use pocketmine\network\mcpe\protocol\SetDisplayObjectivePacket;
 use pocketmine\network\mcpe\protocol\SetScorePacket;
 use pocketmine\network\mcpe\protocol\types\ScorePacketEntry;
+use pocketmine\network\NetworkSessionManager;
 use jojoe77777\FormAPI;
 
 
@@ -54,13 +55,14 @@ class AdvancedScoreboard extends PluginBase{
 		if(isset(self::$scoreboard[$player->getName()])){
 			$this->removeScore($player);
 		}
+		$session = new NetworkSession();
 		$packet = new SetDisplayObjectivePacket();
 		$packet->displaySlot = $displaySlot;
 		$packet->objectiveName = "objective";
 		$packet->displayName = $displayName;
 		$packet->criteriaName = "dummy";
 		$packet->sortOrder = $sortOrder;
-		$player->sendDataPacket($packet);
+		$session->sendDataPacket($packet);
 		self::$scoreboard[$player->getName()] = $player->getName();
 	}
 
@@ -69,9 +71,10 @@ class AdvancedScoreboard extends PluginBase{
 	* @return void
 	*/
 	public function removeScore(Player $player) : void{
+		$session = new NetworkSession();
 		$packet = new RemoveObjectivePacket();
 		$packet->objectiveName = "objective";
-		$player->sendDataPacket($packet);
+		$session->sendDataPacket($packet);
 		unset(self::$scoreboard[$player->getName()]);
 	}
 
@@ -100,7 +103,7 @@ class AdvancedScoreboard extends PluginBase{
                         }
                         return false;
                     });
-                    $form->setTitle(TextFormat::GOLD . "§lADVANCED SCOREBOARDS");
+                    $form->setTitle(TextFormat::GOLD . "§lADVANCEDSCOREBOARD");
                     $form->setContent("Select an option");
                     $form->addButton(TextFormat::BOLD . "§l§aShow Scoreboard");
                     $form->addButton(TextFormat::BOLD . "§l§cHide Scoreboard");
@@ -154,11 +157,11 @@ class AdvancedScoreboard extends PluginBase{
 		$pkline->customName = $message;
 		$pkline->score = $line;
 		$pkline->scoreboardId = $line;
-		
+		$session = new NetworkSession();
 		$packet = new SetScorePacket();
 		$packet->type = SetScorePacket::TYPE_CHANGE;
 		$packet->entries[] = $pkline;
-		$player->sendDataPacket($packet);
+		$session->sendDataPacket($packet);
 	}
 
 

--- a/src/varion/AdvancedTask.php
+++ b/src/varion/AdvancedTask.php
@@ -30,14 +30,14 @@ class AdvancedTask extends Task {
     /**
      * @param int $tick
      */
-    public function onRun($tick) : void{
+    public function onRun() : void{
         $worlds = $this->getConfig()->get("worlds", []);
 
         if (empty($worlds)) {
             $this->Score(Server::getInstance()->getOnlinePlayers(), $this->getConfig()->get('default', []));
         }else{
             foreach ($worlds as $world => $title) {
-                $level_world = Server::getInstance()->getWorldByName($world);
+                $level_world = Server::getInstance()->getWorldManager()->getWorldByName($world);
                 if ($level_world instanceof Level) {
                     $this->Score($level_world->getPlayers(), $title);
                 }

--- a/src/varion/AdvancedTask.php
+++ b/src/varion/AdvancedTask.php
@@ -3,9 +3,9 @@
 namespace varion;
 
 use pocketmine\Server;
-use pocketmine\Player;
+use pocketmine\player\Player;
 use pocketmine\utils\Config;
-use pocketmine\level\Level;
+use pocketmine\world\World;
 use pocketmine\scheduler\Task;
 
 class AdvancedTask extends Task {
@@ -37,7 +37,7 @@ class AdvancedTask extends Task {
             $this->Score(Server::getInstance()->getOnlinePlayers(), $this->getConfig()->get('default', []));
         }else{
             foreach ($worlds as $world => $title) {
-                $level_world = Server::getInstance()->getLevelByName($world);
+                $level_world = Server::getInstance()->getWorldByName($world);
                 if ($level_world instanceof Level) {
                     $this->Score($level_world->getPlayers(), $title);
                 }

--- a/src/varion/Event/LevelChangeEvent.php
+++ b/src/varion/Event/LevelChangeEvent.php
@@ -2,7 +2,7 @@
 
 namespace varion\Event;
 
-use pocketmine\Player;
+use pocketmine\player\Player;
 use pocketmine\event\Listener;
 use pocketmine\event\entity\EntityLevelChangeEvent;
 use varion\AdvancedScoreboard;

--- a/src/varion/Event/LevelChangeEvent.php
+++ b/src/varion/Event/LevelChangeEvent.php
@@ -4,7 +4,7 @@ namespace varion\Event;
 
 use pocketmine\player\Player;
 use pocketmine\event\Listener;
-use pocketmine\event\entity\EntityLevelChangeEvent;
+use pocketmine\event\entity\EntityTeleportEvent;
 use varion\AdvancedScoreboard;
 
 class LevelChangeEvent implements Listener{
@@ -19,7 +19,7 @@ class LevelChangeEvent implements Listener{
 		$this->plugin = $plugin;
 	}
 
-	public function onChange(EntityLevelChangeEvent $event) {
+	public function onChange(EntityTeleportEvent $event) {
 		$player = $event->getEntity();
 		if ($player instanceof Player) {
 			$this->plugin->removeScore($player);


### PR DESCRIPTION
The update of AdvancedScoreboard for API 4.0.0 is here!

After 3 years I decided to update it to the newest version of PMMP.

Known issues in this pull request:

World section in config.yml seems to break the plugin, need more tests.
Hide scoreboard with /as not working properly, as the task refresh the scoreboard and check if the player doesn't have the SB, so the synchronous code adds it to the player.